### PR TITLE
Render callback replaced by a list of callbacks.

### DIFF
--- a/ortc/cpp/ortc_MediaStreamTrack.cpp
+++ b/ortc/cpp/ortc_MediaStreamTrack.cpp
@@ -502,7 +502,7 @@ namespace ortc
     {
       AutoRecursiveLock lock(*this);
 
-      mVideoRendererCallback = callback;
+	  mVideoRendererCallbacks.push_back(callback);
       if (mDeviceResource)
         mDeviceResource->setVideoRenderCallback(callback);
     }
@@ -974,8 +974,12 @@ namespace ortc
         return false;
       }
 
-      if (mVideoRendererCallback)
-        mDeviceResource->setVideoRenderCallback(mVideoRendererCallback);
+	  if (!mVideoRendererCallbacks.empty()) {
+		  for (auto i = 0; i < mVideoRendererCallbacks.size(); i++)
+		  {
+			  mDeviceResource->setVideoRenderCallback(mVideoRendererCallbacks.at(i));
+		  }
+	  }
 
       ZS_LOG_DEBUG(log("media device is setup") + ZS_PARAM("device", mDeviceResource->getID()))
 

--- a/ortc/cpp/ortc_RTPMediaEngine.cpp
+++ b/ortc/cpp/ortc_RTPMediaEngine.cpp
@@ -2017,8 +2017,9 @@ namespace ortc
       AutoRecursiveLock lock(*this);
 
       if (kind == Kinds::Kind_Video) {
-        mVideoRenderCallbackReferenceHolder = callback;
-        mVideoRendererCallback = dynamic_cast<IMediaStreamTrackRenderCallback*>(callback.get());
+		mVideoRenderCallbackReferenceHolders.push_back(callback);
+		mVideoRendererCallbacks.push_back(dynamic_cast<IMediaStreamTrackRenderCallback*>(callback.get()));
+
       }
     }
 
@@ -2040,9 +2041,12 @@ namespace ortc
 
       AutoRecursiveLock lock(*this);
 
-      if (mVideoRendererCallback) {
-        mVideoRendererCallback->RenderFrame(1, *videoFrame);
-      }
+	  if (!mVideoRendererCallbacks.empty()) {
+		  for (int i = 0; i < mVideoRendererCallbacks.size(); i++) {
+			  auto item = mVideoRendererCallbacks.at(i);
+			  item->RenderFrame(1, *videoFrame);
+		  }
+	  }
     }
 
     //-------------------------------------------------------------------------
@@ -2162,8 +2166,12 @@ namespace ortc
     {
       {
         AutoRecursiveLock lock(*this);
-
-        if (mVideoRendererCallback) mVideoRendererCallback->RenderFrame(1, *frame);
+		if (!mVideoRendererCallbacks.empty()) {
+			for (int i = 0; i < mVideoRendererCallbacks.size(); i++) {
+				auto item = mVideoRendererCallbacks.at(i);
+				item->RenderFrame(1, *frame);
+			}
+		}
       }
 
       auto track = mTrack.lock();

--- a/ortc/internal/ortc_MediaStreamTrack.h
+++ b/ortc/internal/ortc_MediaStreamTrack.h
@@ -695,7 +695,7 @@ namespace ortc
 
       PromiseWithRTPMediaEngineDeviceResourcePtr mDeviceResourceLifetimeHolderPromise;
       UseDeviceResourcePtr mDeviceResource;
-      IMediaStreamTrackRenderCallbackPtr mVideoRendererCallback;
+	  std::vector<IMediaStreamTrackRenderCallbackPtr> mVideoRendererCallbacks;
 
       PromisePtr mCloseDevicePromise;
 

--- a/ortc/internal/ortc_RTPMediaEngine.h
+++ b/ortc/internal/ortc_RTPMediaEngine.h
@@ -1307,8 +1307,8 @@ namespace ortc
         VideoCaptureTransportPtr mTransport;  // keep lifetime of webrtc callback separate from this object
 
         rtc::scoped_refptr<webrtc::VideoCaptureModule> mVideoCaptureModule;
-        IMediaStreamTrackRenderCallback* mVideoRendererCallback {NULL};
-        IMediaStreamTrackRenderCallbackPtr mVideoRenderCallbackReferenceHolder;
+		std::vector<IMediaStreamTrackRenderCallback*> mVideoRendererCallbacks;
+		std::vector<IMediaStreamTrackRenderCallbackPtr> mVideoRenderCallbackReferenceHolders;
 
         std::atomic<ULONG> mFramesSent {};
         std::atomic<ULONG> mFramesReceived {};


### PR DESCRIPTION
When using the returned MediaSource created using the CreateMediaSource method from a VideoTrack, it returns a new MediaSource, but the underline MediaStream only support one rendering callback. Its mean that the first created MediaSource doesn't receive more frames.

This pull request has a main issue that needs to be resolved before merged, when are the callbacks removed from the list?
Also, I don't know if the variable mVideoRenderCallbackReferenceHolders is necessary.